### PR TITLE
Added exit code for server

### DIFF
--- a/tasks/castle.js
+++ b/tasks/castle.js
@@ -414,7 +414,14 @@ module.exports = function (grunt) {
                 specs.forEach(function (spec, index) {
                     mocha.addFile(path.resolve(spec));
                 });
-                mocha.reporter('spec').run(function () {
+                mocha.reporter('spec').run(function (failures) {
+                    // If there are failures, return a fail exit code
+                    if(failures){
+                        process.on('exit', function () {
+                            process.exit(1);
+                        });
+                    }
+
                     callback();
                 });
             }


### PR DESCRIPTION
Currently if you run server tests and one fails, the exit code is still 0, so CI doesn't fail on it.
Taken from https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically.